### PR TITLE
GetReviewGroups doesnt use explicit password

### DIFF
--- a/Processes/Create Review/Create Review/Targets/Reviewboard.cs
+++ b/Processes/Create Review/Create Review/Targets/Reviewboard.cs
@@ -51,7 +51,7 @@ namespace Create_Review
         public static ReviewGroup[] GetReviewGroups(string workingDirectory, string server, string username, string password, Logging logger)
         {
             // Build up the command
-            string commandOptions = string.Format(@"api-get --server {0} --username {1} --password {2} /groups/", server, username, password);
+            string commandOptions = string.Format(@"api-get --server {0} /groups/", server);
             string rbtPath = RB_Tools.Shared.Targets.Reviewboard.Path();
 
             // Update process


### PR DESCRIPTION
Previously, the username and password were passed in to be used as
command line arguments as plain text strings.

This caused them to be logged as plain text in the logging files and
also caused an application exception when the password contained spaces.

Now, it follows the same course of action as request review, where
username and password are omitted.

Attached log file where exception was thrown (making it unable to refresh groups) and leaked password.
[Create Review 16-11-18 11-19-58.txt](https://github.com/leewinder/reviewboard-tool-integration/files/603332/Create.Review.16-11-18.11-19-58.txt)